### PR TITLE
fix: change otel api key header

### DIFF
--- a/crates/storb_cli/src/main.rs
+++ b/crates/storb_cli/src/main.rs
@@ -118,7 +118,7 @@ pub fn main() -> Result<()> {
     } else {
         info!("OTEL API key provided; enabling telemetry");
         let mut otel_headers: HashMap<String, String> = HashMap::new();
-        otel_headers.insert("Otel-Api-Key".to_string(), otel_api_key.to_string());
+        otel_headers.insert("X-Api-Key".to_string(), otel_api_key.to_string());
         let url: String = otel_endpoint.to_owned() + "logs";
 
         let identifier_resource = Resource::builder()

--- a/crates/storb_validator/src/lib.rs
+++ b/crates/storb_validator/src/lib.rs
@@ -84,7 +84,7 @@ pub async fn run_validator(config: ValidatorConfig) -> Result<()> {
         ))
         .build();
     let mut otel_headers: HashMap<String, String> = HashMap::new();
-    otel_headers.insert("Otel-Api-Key".to_string(), config.otel_api_key.clone());
+    otel_headers.insert("X-Api-Key".to_string(), config.otel_api_key.clone());
     let url = config.otel_endpoint.clone() + "metrics";
     let metrics_exporter = MetricExporter::builder()
         .with_http()


### PR DESCRIPTION
change api header from `Otel-Api-Key` to `X-Api-Key` because the telemetry auth seems to be not setting config properly