### PR TITLE
fix: reconnect to subtensor

### DIFF
--- a/crates/storb_base/src/sync.rs
+++ b/crates/storb_base/src/sync.rs
@@ -72,10 +72,14 @@ impl Synchronizable for BaseNeuron {
     ) -> Result<Vec<u16>, Box<dyn StdError + Send + Sync + 'static>> {
         info!("Starting sync_metagraph");
         let start = std::time::Instant::now();
+        let subtensor = Self::get_subtensor_connection(
+            self.config.subtensor.insecure,
+            &self.config.subtensor.address,
+        )
+        .await?;
 
         info!("Getting latest block...");
-        let current_block = self
-            .subtensor
+        let current_block = subtensor
             .blocks()
             .at_latest()
             .await
@@ -83,7 +87,7 @@ impl Synchronizable for BaseNeuron {
         info!("Got latest block in {:?}", start.elapsed());
 
         info!("Getting runtime API...");
-        let runtime_api = self.subtensor.runtime_api().at(current_block.reference());
+        let runtime_api = subtensor.runtime_api().at(current_block.reference());
         let mut local_node_info = self.local_node_info.clone();
         // TODO: error out if cant access chain when calling above functions
 

--- a/crates/storb_validator/src/validator.rs
+++ b/crates/storb_validator/src/validator.rs
@@ -502,8 +502,12 @@ impl Validator {
         }
         let payload = set_weights_payload(config.neuron_config.netuid, weights, 1);
 
-        neuron
-            .subtensor
+        let subtensor = BaseNeuron::get_subtensor_connection(
+            neuron.config.subtensor.insecure,
+            &neuron.config.subtensor.address,
+        )
+        .await?;
+        subtensor
             .tx()
             .sign_and_submit_default(&payload, &neuron.signer)
             .await?;


### PR DESCRIPTION
resolves #112 
Turns out the issue was that the subtensor endpoint closes the connection. To get around this, we simply create a new ws connection every time we want to interact with the chain. 