### PR TITLE
fix: http timeouts

### DIFF
--- a/crates/storb_base/src/constants.rs
+++ b/crates/storb_base/src/constants.rs
@@ -20,8 +20,8 @@ pub const DHT_QUERY_TIMEOUT: u64 = 3;
 /// Buffer size for the DHT database's MPSC channel.
 pub const DB_MPSC_BUFFER_SIZE: usize = 100;
 
-/// Timeout for node HTTP requests.
-pub const CLIENT_TIMEOUT: Duration = Duration::from_secs(1);
+/// Timeout for HTTP requests to /info endpoint.
+pub const INFO_REQ_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Timeout params for upload requests
 pub const MIN_BANDWIDTH: u64 = 20 * 1024; // minimum "bandwidth"

--- a/crates/storb_base/src/sync.rs
+++ b/crates/storb_base/src/sync.rs
@@ -8,7 +8,7 @@ use futures::stream::{self, StreamExt};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
-use crate::constants::{CLIENT_TIMEOUT, SYNC_BUFFER_SIZE};
+use crate::constants::{INFO_REQ_TIMEOUT, SYNC_BUFFER_SIZE};
 use crate::{BaseNeuron, LocalNodeInfo, NodeInfo};
 
 #[derive(Debug, Error)]
@@ -30,14 +30,14 @@ impl Synchronizable for BaseNeuron {
     async fn get_remote_node_info(addr: reqwest::Url) -> Result<LocalNodeInfo, SyncError> {
         debug!("Requesting node info from: {}", addr.to_string());
         let req_client = reqwest::Client::builder()
-            .timeout(CLIENT_TIMEOUT)
+            .timeout(INFO_REQ_TIMEOUT)
             .build()
             .map_err(|e| {
                 error!("Failed to build HTTP client: {:?}", e);
                 SyncError::GetNodeInfoError(format!("Could not build HTTP client: {e}"))
             })?;
 
-        let response = tokio::time::timeout(CLIENT_TIMEOUT, req_client.get(addr.clone()).send())
+        let response = tokio::time::timeout(INFO_REQ_TIMEOUT, req_client.get(addr.clone()).send())
             .await
             .map_err(|e| {
                 error!("Request timed out for {}: {:?}", addr, e);

--- a/crates/storb_validator/src/download.rs
+++ b/crates/storb_validator/src/download.rs
@@ -159,6 +159,11 @@ impl DownloadProcessor {
                     .bytes()
                     .await
                     .context("Failed to read response body")?;
+                debug!(
+                    "Response body preview from provider {:?}: {:?}",
+                    provider,
+                    &body_bytes[0..std::cmp::min(100, body_bytes.len())]
+                );
                 let piece_data = base::piece::deserialise_piece_response(&body_bytes, &piece_hash)
                     .context("Failed to deserialise piece response")?;
 

--- a/crates/storb_validator/src/download.rs
+++ b/crates/storb_validator/src/download.rs
@@ -160,9 +160,16 @@ impl DownloadProcessor {
                     .await
                     .context("Failed to read response body")?;
                 debug!(
-                    "Response body preview from provider {:?}: {:?}",
+                    "Raw body preview from provider {:?}: {:?}",
                     provider,
-                    &body_bytes[0..std::cmp::min(100, body_bytes.len())]
+                    // show first few as readable bytes
+                    &body_bytes[..std::cmp::min(100, body_bytes.len())]
+                );
+                debug!(
+                    "Utf8 body preview from provider {:?}: {:?}",
+                    provider,
+                    // show first few as readable bytes
+                    String::from_utf8_lossy(&body_bytes[..std::cmp::min(100, body_bytes.len())])
                 );
                 let piece_data = base::piece::deserialise_piece_response(&body_bytes, &piece_hash)
                     .context("Failed to deserialise piece response")?;


### PR DESCRIPTION
- increased timeouts for requests to other nodes' `/info` endpoints from 1s -> 5s
- updated retrieval challenge timeout duration to be determined by piece size
- debug log for response preview during downloads